### PR TITLE
- Added day number to join command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | champions | ```!clash champions Aatrox``` | Will display quick information on a specific or multiple champions. |
 | dance | ```!clash dance``` | It is a secret. |
 | help | ```!clash help``` | Asks the bot to print this menu for you. |
-| join | ```!clash join msi2021 Pikachu``` | Asks the bot to register a player with a given Team based on the Tournament and the Team Name. |
+| join | ```!clash join msi2021 1 Pikachu``` | Asks the bot to register a player with a given Team based on the Tournament Name, Day and the Team Name. |
 | ping | ```!clash pong``` | Asks the bot to pong you. |
 | (deprecated) register | ```!clash register msi2021 1``` | Use newTeam. |
 | newTeam | ```!clash newTeam msi2021 1``` | Asks the bot to create a new Team for you based on the tournament provided. |
@@ -25,9 +25,8 @@
 
 ### Note
 -----------
-- You can use the join, register, unregister command with partial input
-    - For example: `!clash join msi2021 pikachu` -> `!clash join m p`
-    - Or: `!clash register msi2021 1` -> `!clash register m 1`
+- You can use the join, unregister, newTeam command with partial input
+    - For example: `!clash join msi2021 1 pikachu` -> `!clash join m 1 p`
 
 - Subscribe functionality has requirement of you to allow direct messages from people who belong to servers that you have joined. 
     - Tip: You can find this setting in discord under User Settings > Privacy & Safety > Server Privacy Defaults > Allow direct messages from server members.  

--- a/commands/join-team-by-name.js
+++ b/commands/join-team-by-name.js
@@ -10,9 +10,11 @@ module.exports = {
     execute: async function (msg, args) {
         const startTime = process.hrtime.bigint();
         if (!args || args.length === 0) {
-            msg.reply("Tournament Name and Team are missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join ***msi2021*** ***Pikachu***");
+            msg.reply("Tournament Name, Tournament Day, and Team are missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join ***msi2021*** ***1*** ***Pikachu***");
         } else if (!args[1]) {
-            msg.reply("Team is missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join msi2021 ***Pikachu***")
+            msg.reply("Tournament Day and Team is missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join msi2021 ***1*** ***Pikachu***");
+        } else if (!args[2]) {
+            msg.reply("Team is missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join msi2021 1 ***Pikachu***");
         } else {
             try {
                 let times = await leagueApi.findTournament(args[0]);

--- a/commands/join-team-by-name.js
+++ b/commands/join-team-by-name.js
@@ -19,7 +19,7 @@ module.exports = {
             try {
                 let times = await leagueApi.findTournament(args[0]);
                 if (times.length === 0) {
-                    msg.reply(`The tournament you are trying to join does not exist ('${args[0]}'). Please use '!clash times' to see valid tournaments.`)
+                    msg.reply(`The tournament you are trying to join does not exist Name ('${args[0]}') Day ('${args[1]}'). Please use '!clash times' to see valid tournaments.`)
                 } else {
                     function buildTournamentDetails(team) {
                         return {
@@ -31,13 +31,13 @@ module.exports = {
 
                     let copy = JSON.parse(JSON.stringify(registerReply));
                     console.log(`Registering ('${msg.author.username}') with Tournaments ('${JSON.stringify(times)}')...`);
-                    await dynamoDBUtils.registerWithSpecificTeam(msg.author.username, msg.guild.name, times, args[1]).then(team => {
+                    await dynamoDBUtils.registerWithSpecificTeam(msg.author.username, msg.guild.name, times, args[2]).then(team => {
                         if (team) {
                             console.log(`Registered ('${msg.author.username}') with Tournament ('${team.tournamentName}') Team ('${team.teamName}').`);
                             copy.fields.push({name: team.teamName, value: team.players, inline: true});
                             copy.fields.push(buildTournamentDetails(team));
                         } else {
-                            copy.description = `Failed to find an available team with the following criteria Tournament ('${args[0]}') Team Name ('${args[1]}')`;
+                            copy.description = `Failed to find an available team with the following criteria Tournament Name ('${args[0]}') Tournament Day ('${args[1]}') Team Name ('${args[2]}')`;
                         }
                         msg.reply({embed: copy});
                     });

--- a/commands/tests/join-team-by-name.unit.test.js
+++ b/commands/tests/join-team-by-name.unit.test.js
@@ -23,7 +23,7 @@ describe('Join an existing Team', () => {
             reply: (value) => messagePassed = value
         };
         await joinTeamByName.execute(msg);
-        expect(messagePassed).toBe("Tournament Name and Team are missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join ***msi2021*** ***Pikachu***");
+        expect(messagePassed).toBe("Tournament Name, Tournament Day, and Team are missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join ***msi2021*** ***1*** ***Pikachu***");
     })
 
     test('When a user requests to join a team, they are required to pass the tournament and Team Name and it is given and empty.', async () => {
@@ -32,17 +32,17 @@ describe('Join an existing Team', () => {
             reply: (value) => messagePassed = value
         };
         await joinTeamByName.execute(msg, []);
-        expect(messagePassed).toBe("Tournament Name and Team are missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join ***msi2021*** ***Pikachu***");
+        expect(messagePassed).toBe("Tournament Name, Tournament Day, and Team are missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join ***msi2021*** ***1*** ***Pikachu***");
     })
 
-    test('When a user requests to join a team with only the tournament, they are required to pass the tournament and Team Name.', async () => {
+    test('When a user requests to join a team with only the tournament, they are required to pass the tournament name and day and Team Name.', async () => {
         let messagePassed = '';
         let msg = {
             reply: (value) => messagePassed = value
         };
         let args = ['msi2021']
         await joinTeamByName.execute(msg, args);
-        expect(messagePassed).toBe("Team is missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join msi2021 ***Pikachu***");
+        expect(messagePassed).toBe("Tournament Day and Team is missing. You can use '!clash teams' to find existing teams. \n ***Usage***: !clash join msi2021 ***1*** ***Pikachu***");
     })
 
     test('When a user requests to join a team and they pass a Tournament that does not exist, they should be notified.', async () => {
@@ -50,7 +50,7 @@ describe('Join an existing Team', () => {
         let msg = {
             reply: (value) => messagePassed = value
         };
-        let args = ['dne', 'Sample Team'];
+        let args = ['dne', '1', 'Sample Team'];
         leagueApi.findTournament = jest.fn().mockResolvedValue([]);
         await joinTeamByName.execute(msg, args);
         expect(messagePassed).toBe(`The tournament you are trying to join does not exist ('${args[0]}'). Please use '!clash times' to see valid tournaments.`);
@@ -67,7 +67,7 @@ describe('Join an existing Team', () => {
                 name: 'TestServer'
             }
         };
-        let args = ['msi2021', 'Sample Team']
+        let args = ['msi2021', '1', 'Sample Team']
         leagueApi.leagueTimes = [
             {
                 tournamentName: "msi2021",
@@ -100,7 +100,7 @@ describe('Join an existing Team', () => {
                 name: 'TestServer'
             }
         };
-        let args = ['msi2021', 'Sample Team']
+        let args = ['msi2021', '1', 'Sample Team']
         leagueApi.leagueTimes = [
             {
                 tournamentName: "msi2021",
@@ -130,7 +130,7 @@ describe('Join Team Error', () => {
                 name: 'Server'
             }
         };
-        let args = ['msi2021', 'Sample Team']
+        let args = ['msi2021', '1', 'Sample Team']
         leagueApi.leagueTimes = [
             {
                 tournamentName: "msi2021",

--- a/commands/tests/join-team-by-name.unit.test.js
+++ b/commands/tests/join-team-by-name.unit.test.js
@@ -53,7 +53,7 @@ describe('Join an existing Team', () => {
         let args = ['dne', '1', 'Sample Team'];
         leagueApi.findTournament = jest.fn().mockResolvedValue([]);
         await joinTeamByName.execute(msg, args);
-        expect(messagePassed).toBe(`The tournament you are trying to join does not exist ('${args[0]}'). Please use '!clash times' to see valid tournaments.`);
+        expect(messagePassed).toBe(`The tournament you are trying to join does not exist Name ('${args[0]}') Day ('${args[1]}'). Please use '!clash times' to see valid tournaments.`);
     })
 
     test('When a user requests to join a team and they pass a Tournament and a Team they should be notified that they have successfully joined a Team.', async () => {
@@ -85,7 +85,7 @@ describe('Join an existing Team', () => {
         leagueApi.findTournament = jest.fn().mockResolvedValue(leagueApi.leagueTimes);
         dynamoDBUtils.registerWithSpecificTeam = jest.fn().mockResolvedValue(sampleRegisterReturn);
         await joinTeamByName.execute(msg, args);
-        expect(dynamoDBUtils.registerWithSpecificTeam).toBeCalledWith(msg.author.username, msg.guild.name, leagueApi.leagueTimes, args[1]);
+        expect(dynamoDBUtils.registerWithSpecificTeam).toBeCalledWith(msg.author.username, msg.guild.name, leagueApi.leagueTimes, args[2]);
         verifyReply(messagePassed, sampleRegisterReturn);
     })
 
@@ -112,8 +112,8 @@ describe('Join an existing Team', () => {
         leagueApi.findTournament = jest.fn().mockResolvedValue(leagueApi.leagueTimes);
         dynamoDBUtils.registerWithSpecificTeam = jest.fn().mockResolvedValue(undefined);
         await joinTeamByName.execute(msg, args);
-        expect(dynamoDBUtils.registerWithSpecificTeam).toBeCalledWith(msg.author.username, msg.guild.name, leagueApi.leagueTimes, args[1]);
-        expect(messagePassed.embed.description).toEqual(`Failed to find an available team with the following criteria Tournament ('${args[0]}') Team Name ('${args[1]}')`)
+        expect(dynamoDBUtils.registerWithSpecificTeam).toBeCalledWith(msg.author.username, msg.guild.name, leagueApi.leagueTimes, args[2]);
+        expect(messagePassed.embed.description).toEqual(`Failed to find an available team with the following criteria Tournament Name ('${args[0]}') Tournament Day ('${args[1]}') Team Name ('${args[2]}')`)
     })
 
 })

--- a/integration/integration.int.test.js
+++ b/integration/integration.int.test.js
@@ -109,7 +109,7 @@ describe('!clash join', () => {
     test('When the User wants to join a specific Team, they should be able to pass the team name and be successfully assigned to them.', async () => {
         let {restrictedChannel, commandPrefix, mockDiscordMessage, mockDiscordBot} = setupBotCommand('join');
         const expectedTeamName = "Absol";
-        mockDiscordMessage.content = mockDiscordMessage.content.concat(" awesome_sauce " + expectedTeamName);
+        mockDiscordMessage.content = mockDiscordMessage.content.concat(" awesome_sauce 1 " + expectedTeamName);
         let tableData = clashTableData.get('ClashTeam');
         let testedTeam = tableData.dataPersisted.find(record => record.teamName === `Team ${expectedTeamName}`);
         expect(testedTeam.players).not.toContain(mockDiscordMessage.author.username);

--- a/templates/help-menu.js
+++ b/templates/help-menu.js
@@ -24,8 +24,8 @@ module.exports = {
             value: "Asks the bot to print this menu for you :smiley:."
         },
         {
-            name: "~~register~~ join - !clash join msi2021 Abra",
-            value: "Asks the bot to assign you to an available Clash team based on the Tournament name and the Team name."
+            name: "~~register~~ join - !clash join msi2021 1 Abra",
+            value: "Asks the bot to assign you to an available Clash team based on the Tournament Name, Day and the Team name."
         },
         {
             name: "~~register~~ newTeam - !clash newTeam > !clash newTeam msi2021 1",


### PR DESCRIPTION
Please include the following in the Pull Request
- What the update is? Join command needed day number passed so that it could filter between specific tournament days. Otherwise, it would select the first day always and would leave the user unable to register for subsequent days.
- Reviewers: @Poss111 
- Issues closed as part of this Pull Request. 
  - Closes #58 

!clash teams
ClashBot
BOT
 — Today at 5:55 PM
League of Legends Clash Teams
Here are the current Clash rosters
Team Accelgor
Roïdräge
Tournament Details
bandle_city Day 2
​
​
Team Abra
Roïdräge
Silv3rshard
TheIncentive
Tournament Details
bandle_city Day 1
Tentative Queue
bandle_city -> PepeConrad,silverfang
Made by Daniel Poss (aka Roïdräge) - https://github.com/Poss111
silverfang — Today at 5:55 PM
Accelgor needs to have a capital A
Silv3rshard — Today at 5:56 PM
!clash join bandle Accelgor
ClashBot
BOT
 — Today at 5:56 PM
Registration
Failed to find an available team with the following criteria Tournament ('bandle') Team Name ('Accelgor')
Made by Daniel Poss (aka Roïdräge) - https://github.com/Poss111
