### PR TITLE
Hotfix/team api

### DIFF
--- a/src/commands/join-team-by-name.js
+++ b/src/commands/join-team-by-name.js
@@ -166,7 +166,10 @@ module.exports = {
             }
         } catch (error) {
             if (error.status === 400) {
-                logger.error({ ...loggerContext, ...error });
+                logger.error({
+                    ...loggerContext,
+                    error: { status: error.status, body: error.body, response: error.response }}
+                );
                 await msg.editReply(`Failed to find an available team with the following criteria, Role '${args[0]}' Tournament Name '${args[1]}' Tournament Day '${args[2]}' Team Name '${args[3]}' or role is not available for that team`);
             } else {
                 await errorHandling.handleError(

--- a/src/commands/suggest-champion.js
+++ b/src/commands/suggest-champion.js
@@ -62,7 +62,10 @@ module.exports = {
             }
         } catch (error) {
             if (error.status === 400) {
-                logger.error({ ...loggerContext, error });
+                logger.error({
+                    ...loggerContext,
+                    error: { status: error.status, body: error.body, response: error.response }}
+                );
                 await msg.editReply('Sorry! You cannot have more than 5 champions in your list. ' +
                   'Please remove by passing a champion in your list and then try adding again. Thank you!');
             } else {

--- a/src/commands/teams.js
+++ b/src/commands/teams.js
@@ -78,7 +78,9 @@ module.exports = {
                         message = message.concat('\n');
                     }
                 }
-                copy.fields.push({name: 'Tentative Queue', value: message});
+                if (message !== '') {
+                    copy.fields.push({name: 'Tentative Queue', value: message});
+                }
             }
             logger.debug({ ...loggerContext, discordMsg: { embeds: [ copy ] }}, 'Message to be sent to the User.');
             await msg.editReply({embeds: [ copy ]});

--- a/src/commands/tentative.js
+++ b/src/commands/tentative.js
@@ -71,10 +71,13 @@ module.exports = {
                 logger.info(loggerContext, `Total found Tournaments ('${Array.isArray(times) ? times.length : 0}')`);
                 if (Array.isArray(times) && times.length > 0) {
                     const tentativeApi = new ClashBotRestClient.TentativeApi(client());
-                    const tentativeDetails = await tentativeApi.getTentativeDetails({
+                    const tentativeDetails = await tentativeApi.getTentativeDetails(
+                      msg.member.guild.name,
+                      {
                         tournamentName: times[0].tournamentName,
                         tournamentDay: times[0].tournamentDay,
-                    });
+                      }
+                    );
                     const foundTentative = tentativeDetails
                       .find(tentativeDetail => tentativeDetail
                         .tentativePlayers.find(player => player.id === msg.user.id));

--- a/src/commands/tentative.js
+++ b/src/commands/tentative.js
@@ -102,14 +102,13 @@ module.exports = {
                     } else {
                         let opts = {
                             'placePlayerOnTentativeRequest': new ClashBotRestClient
-                              .PlacePlayerOnTentativeRequest({
-                                  serverName       : msg.member.guild.name,
-                                  tournamentDetails: {
+                              .PlacePlayerOnTentativeRequest(
+                                  msg.member.guild.name,
+                                  {
                                       tournamentName: times[0].tournamentName,
                                       tournamentDay : times[0].tournamentDay,
                                   },
-                                  playerId: msg.user.id,
-                              })
+                                  msg.user.id),
                         };
                         logger.debug({ ...loggerContext, request: opts }, 'Request to Post Tentative.');
                         await tentativeApi.placePlayerOnTentative(opts);

--- a/src/commands/tentative.js
+++ b/src/commands/tentative.js
@@ -79,6 +79,15 @@ module.exports = {
                       .find(tentativeDetail => tentativeDetail
                         .tentativePlayers.find(player => player.id === msg.user.id));
                     if (foundTentative) {
+                        logger.debug({
+                            ...loggerContext,
+                            request: {
+                                serverName: msg.member.guild.name,
+                                id: msg.user.id,
+                                tournament: times[0].tournamentName,
+                                tournamentDay: times[0].tournamentDay
+                            }
+                        }, 'Request to Delete Tentative.');
                         await tentativeApi
                           .removePlayerFromTentative(
                             msg.member.guild.name,
@@ -93,12 +102,13 @@ module.exports = {
                               .PlacePlayerOnTentativeRequest({
                                   serverName       : msg.member.guild.name,
                                   tournamentDetails: {
-                                      tournamentName: '',
-                                      tournamentDay : '',
+                                      tournamentName: times[0].tournamentName,
+                                      tournamentDay : times[0].tournamentDay,
                                   },
                                   playerId: msg.user.id,
                               })
                         };
+                        logger.debug({ ...loggerContext, request: opts }, 'Request to Post Tentative.');
                         await tentativeApi.placePlayerOnTentative(opts);
                         await msg.editReply('We placed you into the tentative queue. If you were on a team, you have been removed. tip: Use \'/teams\' to view current team status');
                     }

--- a/src/commands/tests/teams.unit.test.js
+++ b/src/commands/tests/teams.unit.test.js
@@ -450,6 +450,86 @@ describe('Retrieve Teams', () => {
             expect(msg.editReply).toHaveBeenCalledTimes(1);
             expect(msg.editReply).toHaveBeenCalledWith({ embeds: [ copy ]});
         });
+
+        test('When multiple tentative records and a team are passed back and all have empty Tentative Player lists, it should populate with the existing team based on all the tournaments.', async () => {
+            let msg = buildMockInteraction();
+            const sampleTeamTwoPlayers = [
+                {
+                    name: 'abra',
+                    playerDetails: {
+                        Top: {
+                            id: 1,
+                            name: 'Roïdräge',
+                            champions: ['Volibear', 'Ornn', 'Sett'],
+                            role: 'Top'
+                        },
+                        Bot: {
+                            id: 2,
+                            name: 'TheIncentive',
+                            champions: ['Lucian'],
+                            role: 'Bot'
+                        },
+                        Jg: {
+                            id: 3,
+                            name: 'Pepe Conrad',
+                            champions: ['Lucian'],
+                            role: 'Jg'
+                        }
+                    },
+                    tournament: {
+                        tournamentName: 'awesome_sauce',
+                        tournamentDay: '1'
+                    }
+                }
+            ];
+            let sampleTentativeList = [{
+                serverName: msg.member.guild.name,
+                tournamentDetails: {
+                    tournamentName: 'awesome_sauce',
+                    tournamentDay: '1'
+                },
+                tentativePlayers: []
+            }, {
+                serverName: msg.member.guild.name,
+                tournamentDetails: {
+                    tournamentName: 'awesome_sauce',
+                    tournamentDay: '2'
+                },
+                tentativePlayers: []
+            }, {
+                serverName: msg.member.guild.name,
+                tournamentDetails: {
+                    tournamentName: 'awesome_sauce',
+                    tournamentDay: '3'
+                },
+                tentativePlayers: []
+            }];
+
+            let parsedResponse = [{ ...sampleTeamTwoPlayers[0] }];
+            parsedResponse[0].name = 'Abra';
+
+            const getTentativeDetailsMock = jest.fn();
+            clashBotRestClient.TentativeApi.mockReturnValue({
+                getTentativeDetails: getTentativeDetailsMock
+                  .mockResolvedValue(sampleTentativeList)
+            });
+            const getTeamMock = jest.fn();
+            clashBotRestClient.TeamApi.mockReturnValue({
+                getTeam: getTeamMock.mockResolvedValue(sampleTeamTwoPlayers)
+            });
+            let copy = buildExpectedTeamsResponse(parsedResponse);
+            await teams.execute(msg);
+            expect(errorHandling.handleError).not.toHaveBeenCalled();
+            expect(getTentativeDetailsMock).toHaveBeenCalledTimes(1);
+            expect(getTentativeDetailsMock)
+              .toHaveBeenCalledWith(msg.member.guild.name);
+            expect(getTeamMock).toHaveBeenCalledTimes(1);
+            expect(getTeamMock)
+              .toHaveBeenCalledWith(msg.member.guild.name);
+            expect(msg.deferReply).toHaveBeenCalledTimes(1);
+            expect(msg.editReply).toHaveBeenCalledTimes(1);
+            expect(msg.editReply).toHaveBeenCalledWith({ embeds: [ copy ]});
+        });
     });
 
     describe('Error', () => {

--- a/src/commands/tests/tentative.unit.test.js
+++ b/src/commands/tests/tentative.unit.test.js
@@ -107,10 +107,13 @@ describe('Tentative Command', () => {
                 day: args[1],
             });
             expect(getTentativeMock).toHaveBeenCalledTimes(1);
-            expect(getTentativeMock).toHaveBeenCalledWith({
+            expect(getTentativeMock).toHaveBeenCalledWith(
+              msg.member.guild.name,
+              {
                 tournamentName: args[0],
                 tournamentDay: args[1],
-            });
+              }
+            );
             expect(placePlayerOnTentativeMock).toHaveBeenCalledTimes(1);
             expect(placePlayerOnTentativeMock)
               .toHaveBeenCalledWith(expectedRequest);
@@ -183,10 +186,12 @@ describe('Tentative Command', () => {
                 day: args[1],
             });
             expect(getTentativeMock).toHaveBeenCalledTimes(1);
-            expect(getTentativeMock).toHaveBeenCalledWith({
+            expect(getTentativeMock).toHaveBeenCalledWith(
+              msg.member.guild.name,
+              {
                 tournamentName: leagueTimes[0].tournamentName,
                 tournamentDay: leagueTimes[0].tournamentDay,
-            });
+              });
             expect(placePlayerOnTentativeMock)
               .not
               .toHaveBeenCalled();
@@ -355,7 +360,9 @@ describe('Tentative Command', () => {
                 day: args[1],
             });
             expect(getTentativeMock).toHaveBeenCalledTimes(1);
-            expect(getTentativeMock).toHaveBeenCalledWith({
+            expect(getTentativeMock).toHaveBeenCalledWith(
+              msg.member.guild.name,
+              {
                 tournamentName: args[0],
                 tournamentDay: args[1],
             });
@@ -435,7 +442,9 @@ describe('Tentative Command', () => {
                 day: args[1],
             });
             expect(getTentativeMock).toHaveBeenCalledTimes(1);
-            expect(getTentativeMock).toHaveBeenCalledWith({
+            expect(getTentativeMock).toHaveBeenCalledWith(
+              msg.member.guild.name,
+              {
                 tournamentName: args[0],
                 tournamentDay: args[1],
             });
@@ -520,7 +529,9 @@ describe('Tentative Command', () => {
                 day: args[1],
             });
             expect(getTentativeMock).toHaveBeenCalledTimes(1);
-            expect(getTentativeMock).toHaveBeenCalledWith({
+            expect(getTentativeMock).toHaveBeenCalledWith(
+              msg.member.guild.name,
+              {
                 tournamentName: args[0],
                 tournamentDay: args[1],
             });

--- a/src/commands/tests/unregister.unit.test.js
+++ b/src/commands/tests/unregister.unit.test.js
@@ -390,36 +390,6 @@ describe('Unregister', () => {
                 tournamentDay: args[1],
                 createNewTeam: false
             });
-            const sampleTeamTwoPlayers = [
-                {
-                    name: 'abra',
-                    serverName: msg.member.guild.name,
-                    playerDetails: {
-                        Top: {
-                            id: 1,
-                            name: 'Roïdräge',
-                            champions: ['Volibear', 'Ornn', 'Sett'],
-                            role: 'Top'
-                        },
-                        Bot: {
-                            id: msg.user.id,
-                            name: msg.user.username,
-                            champions: ['Lucian'],
-                            role: 'Bot'
-                        },
-                        Jg: {
-                            id: 3,
-                            name: 'Pepe Conrad',
-                            champions: ['Lucian'],
-                            role: 'Jg'
-                        }
-                    },
-                    tournament: {
-                        tournamentName: 'awesome_sauce',
-                        tournamentDay: '1'
-                    }
-                }
-            ];
             let getTournamentsMock = jest.fn();
             clashBotRestClient.TournamentApi.mockReturnValue({
                 getTournaments: getTournamentsMock.mockResolvedValue(leagueTimes)

--- a/src/commands/unregister.js
+++ b/src/commands/unregister.js
@@ -80,7 +80,7 @@ module.exports = {
                           times[0].tournamentDay,
                           msg.user.id
                         );
-                        await msg.editReply(`Removed you from Team '${response.name}' for Tournament '${response.tournament.tournamentName} - ${response.tournament.tournamentDay}'. Please use /join or /newTeam if you would like to join again. Thank you!`);
+                        await msg.editReply(`Removed you from Team '${response.name}' for Tournament '${times[0].tournamentName} - ${times[0].tournamentDay}'. Please use /join or /newTeam if you would like to join again. Thank you!`);
                     } else {
                         await msg.editReply(`You do not belong to any of the Teams for Tournament '${times[0].tournamentName}' on day '${times[0].tournamentDay}'.`);
                     }

--- a/src/commands/unregister.js
+++ b/src/commands/unregister.js
@@ -63,14 +63,27 @@ module.exports = {
                     logger.info(loggerContext, `Found ('${times ? times.length : 0}') Tournaments.`);
                     await msg.editReply(`Unregistering '${msg.user.username}' from Tournament '${times[0].tournamentName}' on day '${times[0].tournamentDay}'...`);
                     const teamApi = new ClashBotRestClient.TeamApi(client());
-                    const response = await teamApi.removePlayerFromTeam(
-                      undefined,
+                    const teams = await teamApi.getTeam(
                       msg.member.guild.name,
-                      times[0].tournamentName,
-                      times[0].tournamentDay,
-                      msg.user.id
+                      {
+                          tournament: times[0].tournamentName,
+                          day: times[0].tournamentDay,
+                      }
                     );
-                    await msg.editReply(`Removed you from Team '${response.name}' for Tournament '${response.tournament.tournamentName} - ${response.tournament.tournamentDay}'. Please use /join or /newTeam if you would like to join again. Thank you!`);
+                    const foundTeam = teams.find(team => Object.entries(team.playerDetails)
+                      .find(entry => entry[1].id === msg.user.id));
+                    if (foundTeam) {
+                        const response = await teamApi.removePlayerFromTeam(
+                          foundTeam.name,
+                          msg.member.guild.name,
+                          times[0].tournamentName,
+                          times[0].tournamentDay,
+                          msg.user.id
+                        );
+                        await msg.editReply(`Removed you from Team '${response.name}' for Tournament '${response.tournament.tournamentName} - ${response.tournament.tournamentDay}'. Please use /join or /newTeam if you would like to join again. Thank you!`);
+                    } else {
+                        await msg.editReply(`You do not belong to any of the Teams for Tournament '${times[0].tournamentName}' on day '${times[0].tournamentDay}'.`);
+                    }
                 } else {
                     logger.info(loggerContext, `Unable to find a Tournament based on Tournament ('${parsedArguments.tournamentName}') Day ('${parsedArguments.tournamentDay}').`);
                     await msg.editReply('Please provide an existing tournament and day to unregister for. ' +

--- a/src/commands/unregister.js
+++ b/src/commands/unregister.js
@@ -92,7 +92,10 @@ module.exports = {
             }
         } catch (error) {
             if (error.status === 400) {
-                logger.error({...loggerContext, ...error});
+                logger.error({
+                    ...loggerContext,
+                    error: { status: error.status, body: error.body, response: error.response }}
+                );
                 await msg.editReply(`We did not find you on an existing Team for Tournament '${args[0]} - ${args[1]}'. Please use /join or /newTeam if you would like to join again. Thank you!`);
             } else {
                 await errorHandler.handleError(

--- a/src/utility/error-handling.js
+++ b/src/utility/error-handling.js
@@ -4,7 +4,7 @@ class ErrorHandling {
     async handleError(command, error, msg, userMessage, loggerContext) {
         if (error.status) {
             logger.error({ ...loggerContext,
-                error: { status: error.status, message: error.message, stack: error.stack }
+                error: { status: error.status, body: error.body, response: error.response }
             });
         } else {
             logger.error({ ...loggerContext, error: { message: error.message, stack: error.stack } });

--- a/src/utility/error-handling.js
+++ b/src/utility/error-handling.js
@@ -2,7 +2,13 @@ const logger = require('../utility/logger');
 
 class ErrorHandling {
     async handleError(command, error, msg, userMessage, loggerContext) {
-        logger.error({ ...loggerContext, error: { message: error.message, stack: error.stack } });
+        if (error.status) {
+            logger.error({ ...loggerContext,
+                error: { status: error.status, message: error.message, stack: error.stack }
+            });
+        } else {
+            logger.error({ ...loggerContext, error: { message: error.message, stack: error.stack } });
+        }
         await msg.editReply(`${userMessage}. Please reach out to <@299370234228506627>.`);
     }
 }

--- a/tfe/main.tf
+++ b/tfe/main.tf
@@ -468,6 +468,7 @@ resource "aws_ecs_service" "clash-bot-discord-bot-service" {
   task_definition                    = aws_ecs_task_definition.clash-bot-discord-bot-task-def.arn
   desired_count                      = var.app_count
   launch_type                        = "FARGATE"
+  force_new_deployment               = true
   deployment_minimum_healthy_percent = 0
   deployment_maximum_percent         = 100
 


### PR DESCRIPTION
# What the update is?
  - Needed to fix a few commands that were failing after integration.
    - unregister - Due to passing Team name as undefined. Needed to find actual Team that player belonged to.
    - tentative - Due to improper building of request
    - teams - Due to Tentative records being returned with no players
# Reviewers: @Poss111
